### PR TITLE
addBank() Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ __pycache__/
 
 build/
 dist/
+.idea/
 ng_banks.egg-info

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The package contains two methods:
 >>> getBank('GTB') # returns {'name': 'GUARANTY TRUST BANK PLC', 'code': '058', 'slug': 'GTB', 'ussd_code': '*737#' }
 
 >>> getBank('044') # returns {'name': 'ACCESS BANK PLC', 'code': '044', 'slug': 'ACC', 'ussd_code': '*901#' }
+
+>>> addBank(name, code, slug, ussd_code) # Extend the list of banks on the fly. Returns a new bank dict or throws Exception if bank already exists.
 ```
 
 ### CONTRIBUTORS

--- a/ng_banks/__init__.py
+++ b/ng_banks/__init__.py
@@ -56,3 +56,12 @@ def getBank(_param):
         return bank[0]
     except IndexError:
         return None
+
+def addBank(name, code, slug, ussd_code=None):
+    
+    for index, bank in enumerate(banks):
+        if bank['code'] == code or bank['slug'] == slug:
+            raise Exception('Bank Already Exists With This Code or Slug')
+    bank = {'name': name.upper(), 'code':code, 'slug':slug, 'ussd_code':ussd_code}
+    banks.append(bank)
+    return bank


### PR DESCRIPTION
Added an `addBank()` method. Banks not in default list can be added on the fly.

Simple Usage

```
import ng_banks

ng_banks.addBank(name='Cobhams Savings and Loans', code='007', slug='CSL', ussd_code='*007#') 
```
If successful, returns 
```
{'name': 'COBHAMS SAVINGS AND LOANS', 'code': '007', 'slug': 'CSL', 'ussd_code': '*007#'}
```

If bank with code or slug already exists, `raises Exception` with message `Bank Already Exists With This Code or Slug`